### PR TITLE
Only set highlight if not previously set by user

### DIFF
--- a/lua/colorful-winsep/view.lua
+++ b/lua/colorful-winsep/view.lua
@@ -126,7 +126,9 @@ end
 
 function M.highlight()
   local opts = M.config.highlight
-  vim.api.nvim_set_hl(0, 'NvimSeparator', opts)
+  if vim.tbl_isempty(vim.api.nvim_get_hl(0, { name = "NvimSeparator" })) then
+    vim.api.nvim_set_hl(0, "NvimSeparator", opts)
+  end
 end
 
 function M.set_config(opts)


### PR DESCRIPTION
On every window focus, the highlight would get reset to the default if it was not specified in the plugin's setup.

This will allow for setting the highlight of the window separator to a custom value that is set later in the user's config. Such as when setting up a colorscheme after the plugin has already been loaded.