### PR TITLE
Fix separator being off on session load

### DIFF
--- a/lua/colorful-winsep/config.lua
+++ b/lua/colorful-winsep/config.lua
@@ -3,7 +3,7 @@ local M = {
 		symbols = { "━", "┃", "┏", "┓", "┗", "┛" },
 		no_exec_files = { "packer", "TelescopePrompt", "mason", "CompetiTest", "neo-tree" },
 		hi = { fg = "#957CC6", bg = vim.api.nvim_get_hl_by_name("Normal", true)["background"] },
-		events = { "WinEnter", "BufEnter", "WinResized", "WinClosed", "VimResized" },
+		events = { "WinEnter", "BufEnter", "WinResized", "WinClosed", "VimResized", "SessionLoadPost" },
 		smooth = true,
 		exponential_smoothing = true,
 		anchor = {


### PR DESCRIPTION
Without this event, the split border is off:

<img width="1512" alt="Screenshot 2024-05-01 at 13 06 38" src="https://github.com/nvim-zh/colorful-winsep.nvim/assets/11805218/26239e1c-2e7f-42e9-9e84-a1a38671b0c6">

With the `SessionLoadPost` event, the border is placed in the correct place. I am not sure this is the optimal way to solve these kind of issues, but it works.

