### PR TITLE
Explicitly set border to "none" to avoid inheriting default border

### DIFF
--- a/lua/colorful-winsep/line.lua
+++ b/lua/colorful-winsep/line.lua
@@ -17,6 +17,7 @@ function M:create_line()
     window = nil,
     opts = {
       style = "minimal",
+      border = "none",
       relative = "editor",
       zindex = 1,
       focusable = false,


### PR DESCRIPTION
As of Nvim 0.11, the user can set a default border for all floating windows (`vim.o.winborder`). This also applies to the window created by colorful-winsep. Explicitly setting the border to `"none"` fixes this.

Here's the undesirable behavior with `vim.o.winborder` set to `"single"`:
![winsep](https://github.com/user-attachments/assets/ebebc322-16fb-4a7b-b7dd-84e209061de5)
