### PR TITLE
Fix window race condition with yazi.nvim

### DIFF
--- a/lua/colorful-winsep/separator.lua
+++ b/lua/colorful-winsep/separator.lua
@@ -118,11 +118,16 @@ end
 
 --- show the separator window
 function Separator:show()
-    if vim.api.nvim_buf_is_valid(self.buffer) then
-        local win = api.nvim_open_win(self.buffer, false, self.window)
-        api.nvim_set_option_value("winhl", "Normal:ColorfulWinSep", { win = win })
-        self.winid = win
-        self._show = true
+    if api.nvim_buf_is_valid(self.buffer) then
+        vim.schedule(function()
+            if not api.nvim_buf_is_valid(self.buffer) then
+                return
+            end
+            local win = api.nvim_open_win(self.buffer, false, self.window)
+            api.nvim_set_option_value("winhl", "Normal:ColorfulWinSep", { win = win })
+            self.winid = win
+            self._show = true
+        end)
     end
 end
 


### PR DESCRIPTION
When I use this plugin with yazi.nvim 

```bash
...ias/.local/share/nvim/lazy/yazi.nvim/lua/yazi/window.lua:35: WinEnter Autocommands for "*": Vim(append):Lua callback: ...y/colorful-winsep.nvim/lua/colorful-winsep/separator.lua:122: E242: Can't split a window while closing another
stack traceback:
	[C]: in function 'nvim_open_win'
	...y/colorful-winsep.nvim/lua/colorful-winsep/separator.lua:122: in function 'show'
	...m/lazy/colorful-winsep.nvim/lua/colorful-winsep/view.lua:59: in function 'render_left'
	...m/lazy/colorful-winsep.nvim/lua/colorful-winsep/view.lua:274: in function 'render'
	...m/lazy/colorful-winsep.nvim/lua/colorful-winsep/init.lua:71: in function <...m/lazy/colorful-winsep.nvim/lua/colorful-winsep/init.lua:53>
	[C]: in function 'nvim_win_close'
	...ias/.local/share/nvim/lazy/yazi.nvim/lua/yazi/window.lua:35: in function 'close'
	...lias/.local/share/nvim/lazy/yazi.nvim/lua/yazi/utils.lua:484: in function 'on_yazi_exited'
	/Users/alias/.local/share/nvim/lazy/yazi.nvim/lua/yazi.lua:117: in function 'on_exit'
	...re/nvim/lazy/yazi.nvim/lua/yazi/process/yazi_process.lua:88: in function <...re/nvim/lazy/yazi.nvim/lua/yazi/process/yazi_process.lua:60>
stack traceback:
```
The original separator.lua
```lua
function Separator:show()
    if vim.api.nvim_buf_is_valid(self.buffer) then
        local win = api.nvim_open_win(self.buffer, false, self.window)
        api.nvim_set_option_value("winhl", "Normal:ColorfulWinSep", { win = win })
        self.winid = win
        self._show = true
    end
end
```

the yazi window.lua

```lua

function YaziFloatingWindow:close()
  pcall(self.cleanup)

  if vim.api.nvim_win_is_valid(self.win) then
    vim.api.nvim_win_close(self.win, true)
    Log:debug(
      string.format(
        "YaziFloatingWindow closing (content_buffer: %s, win: %s)",
        self.content_buffer,
        self.win
      )
    )
  end

  vim.schedule(function()
    if
      vim.api.nvim_buf_is_valid(self.content_buffer)
      and vim.api.nvim_buf_is_loaded(self.content_buffer)
    then
      vim.api.nvim_buf_delete(self.content_buffer, { force = true })
    end
  end)
end

```
They have the race condition which cause the error
I can confirm this patch can works.
