### PR TITLE
refactor: fix bug when switching theme from dark and light

### DIFF
--- a/lua/colorful-winsep/init.lua
+++ b/lua/colorful-winsep/init.lua
@@ -5,9 +5,11 @@ local M = {}
 M.enabled = true
 
 local function highlight()
-    if vim.tbl_isempty(vim.api.nvim_get_hl(0, { name = "ColorfulWinSep" })) then
-        vim.api.nvim_set_hl(0, "ColorfulWinSep", config.opts.highlight)
-    end
+    -- always get fresh background color from current colorscheme
+    local fresh_highlight = vim.tbl_deep_extend("force", config.opts.highlight, {
+        bg = vim.api.nvim_get_hl(0, { name = "Normal" }).bg,
+    })
+    vim.api.nvim_set_hl(0, "ColorfulWinSep", fresh_highlight)
 end
 
 local function create_command()


### PR DESCRIPTION
Fixes issue from: https://github.com/nvim-zh/colorful-winsep.nvim/issues/88

## Problem
When changing colorschemes (from dark to light and vice versa), window separator colors don't update because the background color is captured once during plugin initialization and never refreshed.

## Root Cause
In `config.lua`, the highlight configuration captures `vim.api.nvim_get_hl(0, { name = "Normal" }).bg` at load time:
```lua
highlight = { fg = "#957CC6", bg = vim.api.nvim_get_hl(0, { name = "Normal" }).bg }
```
Even though there's already a ColorScheme autocmd in init.lua, it doesn't help because the background color remains the cached value from initialization.

## Solution
Modified the `highlight()` function in `init.lua` to dynamically fetch the background color from the current colorscheme on each call.