### PR TITLE
fix(highlight): prevent overwriting colorscheme highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The highlight's name is `ColorfulWinSep`. You can change it using nvim's builtin
 
 If you want to change it through plugin's setup function, you can pass a string or function to the `highlight` field. When you pass a string, it will work as the fg, and the bg will be linked to "Normal" highlight group automatically (see `:h hl-Normal`). When you pass a function, the function will be called when the plugin runs and every time the colorscheme is changed.
 
-If you don't want the plugin do anything about the highlight in certain situations, such as your colorscheme creates the highlights on its own (like catppuccin), you can pass a empty function to `highlight` field (namely `highlight = function() end`) then manipulate the `ColorfulWinSep` as you wish.
+If you don't want the plugin do anything about the highlight in certain situations, such as your colorscheme creates the highlights on its own (like catppuccin), you can pass `nil` to the highlight setting. (this is the default)
 
 ## TODO
 - [ ] add marquee

--- a/lua/colorful-winsep/config.lua
+++ b/lua/colorful-winsep/config.lua
@@ -4,7 +4,7 @@ M.opts = {
     -- Or pass a table like this: { "─", "│", "┌", "┐", "└", "┘" },
     border = "bold",
     excluded_ft = { "packer", "TelescopePrompt", "mason" },
-    highlight = "#957CC6", -- string or function. See the docs's Highlights section
+    highlight = nil, -- string or function. See the docs's Highlights section
     animate = {
         enabled = "shift", -- false to disable or choose a option below (e.g. "shift") and set option for it if needed
         shift = {
@@ -57,6 +57,16 @@ function M.merge_config(user_opts)
         end
     elseif type(M.opts.highlight) == "table" then
         vim.notify("Colorful-winsep: highlight field don't support table now, check the docs!", vim.log.levels.ERROR)
+    elseif type(M.opts.highlight) == "nil" then
+        M.opts.highlight = function()
+            if vim.tbl_isempty(vim.api.nvim_get_hl(0, { name = "ColorfulWinSep" })) then
+                vim.api.nvim_set_hl(
+                    0,
+                    "ColorfulWinSep",
+                    { fg = "#957CC6", bg = vim.api.nvim_get_hl(0, { name = "Normal" }).bg }
+                )
+            end
+        end
     end
 end
 

--- a/lua/colorful-winsep/init.lua
+++ b/lua/colorful-winsep/init.lua
@@ -91,6 +91,12 @@ function M.setup(user_opts)
     end
 
     config.opts.highlight()
+    api.nvim_create_autocmd({ "ColorSchemePre" }, {
+        group = auto_group,
+        callback = function()
+            api.nvim_set_hl(0, "ColorfulWinSep", {})
+        end,
+    })
     api.nvim_create_autocmd({ "ColorScheme" }, {
         group = auto_group,
         callback = config.opts.highlight,


### PR DESCRIPTION
highlights were previously overwritten by the plugin by default - since `opts.highlight` was set.
with this pr, an empty option (which is now the default) checks for a highlight set by the colorscheme and falls back to the default if its empty.

previous versions ( https://github.com/nvim-zh/colorful-winsep.nvim/commit/794a644 ) used to do this check but it was deleted later in https://github.com/nvim-zh/colorful-winsep.nvim/commit/ecff5f4c78e0c34e5eeb8d2ad938c6be269c1d5f .

related:
- https://github.com/nvim-zh/colorful-winsep.nvim/commit/ecff5f4c78e0c34e5eeb8d2ad938c6be269c1d5f
- https://github.com/nvim-zh/colorful-winsep.nvim/commit/0aca6e66c6f0cff308bcd23cc090a4b28e9924bc
- https://github.com/catppuccin/nvim/issues/912